### PR TITLE
chore: switch to ubuntu from windows

### DIFF
--- a/.github/workflows/e2e_cypress_tests.yml
+++ b/.github/workflows/e2e_cypress_tests.yml
@@ -9,7 +9,7 @@ on:
   # - "pull_request"
 jobs:
   cypress-run:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
We have to pay extra for workflows using windows. This only changes what system the test is run on without changing what is run.