### PR TITLE
feat(docs): shared-memory system with PR-time doc-sync enforcement

### DIFF
--- a/.claude/skills/doc-review/SKILL.md
+++ b/.claude/skills/doc-review/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: doc-review
+description: Run a scheduled freshness review of one memory doc against the current repo, then bump its last-reviewed date. Use when the doc-freshness issue or scripts/check-doc-freshness.sh reports a doc overdue, or when asked to review a doc.
+---
+
+# doc-review: verify a memory doc against reality
+
+Memory docs decay: code moves on, vendors ship, rules change. A review walks
+one doc claim by claim and either confirms, fixes, or flags each one, then
+bumps `last-reviewed` so the freshness system knows it was done. See
+`docs/README.md` for the system this belongs to.
+
+## Steps
+
+1. **Pick the doc.** If none was named, run `scripts/check-doc-freshness.sh`
+   and take the most overdue one. Review one doc per pass; small and complete
+   beats broad and shallow.
+2. **Establish the doc's sources of truth.** From `docs/doc-map.tsv`, find the
+   code areas the doc covers. Note which claims are verifiable from the repo
+   and which rest on external sources (vendor docs, Elections Ontario
+   guidance, Drive documents, Slack).
+3. **Verify claim by claim.** For each factual claim, path, command, and
+   cross-reference in the doc:
+   - **confirmed** → leave it;
+   - **stale** → fix it (repo-verifiable claims: check the code, run the
+     command; do not guess);
+   - **unverifiable from the repo** → leave it, but if it looks doubtful, add
+     it to `open-questions.md` with what would confirm it.
+4. **Look for the missing.** Scan the mapped code areas (and recent commits
+   touching them, `git log --oneline -- <area>`) for things that exist but the
+   doc does not mention. Add what a future reader would need.
+5. **Reassess the cadence.** If the doc churned a lot, shorten
+   `review-interval-days`; if it was all confirmed, consider lengthening.
+   Adjust only with a reason, and say so in your reply.
+6. **Bump the frontmatter.** Set `last-reviewed` to today (UTC). Do this even
+   when nothing else changed: the review itself is the event being recorded.
+7. **Commit and report.** Commit as `docs: review <doc>` describing what was
+   confirmed, fixed, and flagged. If nothing changed, the commit is just the
+   frontmatter bump. Deliver the fixed/flagged list in your reply.
+
+## Writing conventions
+
+Concise and factual, Canadian spelling, Oxford comma, no em-dashes, no
+horizontal rule directly above a header, text-based formats only (Markdown,
+Mermaid, CSV/TSV). Write for a reader with zero session context.

--- a/.claude/skills/doc-sync/SKILL.md
+++ b/.claude/skills/doc-sync/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: doc-sync
+description: Fold a code change into the area's memory docs. Use when the Doc Sync PR check fails, or proactively after changing behaviour in an area listed in docs/doc-map.tsv.
+---
+
+# doc-sync: fold a code change into shared memory
+
+The repo's docs are shared memory for humans and agents (see `docs/README.md`).
+This skill is the write path: after changing code in a mapped area, capture
+what a future session would otherwise have to rediscover.
+
+## Steps
+
+1. **Find the affected docs.** Match the files you changed against
+   `docs/doc-map.tsv`. The third column hints at which doc(s) in the area
+   usually need the update.
+2. **Decide what is worth capturing.** Ask: what did this change teach or
+   decide that is not obvious from the code itself? Capture durable facts only:
+   - behaviour or interface changes, and new constraints or invariants;
+   - decisions made (and rejected alternatives, briefly);
+   - external facts learned (API quirks, regulatory rules, vendor commitments);
+   - open questions resolved, or new risks discovered.
+   A pure refactor with no behaviour change usually needs no doc edit; in that
+   case stop here and say so.
+3. **Route each fact to the right doc.** For the tax-receipts area:
+   - architecture, phases, and domain model → `DESIGN.md`;
+   - Qomon or warehouse facts → `integrations.md`;
+   - Elections Ontario rules → `compliance.md`;
+   - decisions → `decisions.md` (append a new `D<n>`; never rewrite an
+     accepted decision, see step 5);
+   - risks and unknowns → `open-questions.md` (mark resolved items ✅ with the
+     answer inline).
+4. **Edit surgically.** Update or delete the sentences the change invalidates;
+   add the new facts where a reader would look for them. Do not append
+   changelog-style notes to the bottom of a doc.
+5. **Contradictions are decisions, not edits.** If your change conflicts with
+   an accepted entry in `decisions.md`, do not silently rewrite the decision.
+   Add the conflict to `open-questions.md` and flag it in your reply; the
+   decision log only changes with explicit sign-off.
+6. **Leave `last-reviewed` alone.** A targeted sync is not a full review; only
+   the doc-review skill bumps the frontmatter.
+7. **Commit docs with the code.** Doc edits ride in the same commit or PR as
+   the change they describe, so review covers both together. This is what the
+   Doc Sync PR check verifies; if a change genuinely has no doc impact, the
+   `docs-not-needed` label on the PR skips the check.
+
+## Writing conventions
+
+Concise and factual, Canadian spelling, Oxford comma, no em-dashes, no
+horizontal rule directly above a header, text-based formats only (Markdown,
+Mermaid, CSV/TSV). Write for a reader with zero session context.

--- a/.github/workflows/doc-freshness.yml
+++ b/.github/workflows/doc-freshness.yml
@@ -1,0 +1,45 @@
+# Weekly check that the memory docs (docs/README.md) are within their review
+# schedule. When any doc is overdue it opens, or updates, a single issue
+# labelled doc-review listing what needs a pass with the doc-review skill.
+name: Doc Freshness
+on:
+  schedule:
+    - cron: '0 13 * * 1' # Mondays 13:00 UTC (morning in Ontario)
+  workflow_dispatch:
+permissions:
+  contents: read
+  issues: write
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check doc freshness
+        id: check
+        run: |
+          if out=$(bash scripts/check-doc-freshness.sh); then
+            echo "All memory docs are within their review schedule."
+          else
+            echo "$out"
+            {
+              echo 'stale<<STALE_EOF'
+              echo "$out"
+              echo 'STALE_EOF'
+            } >> "$GITHUB_OUTPUT"
+          fi
+      - name: Open or update the doc-review issue
+        if: steps.check.outputs.stale != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STALE: ${{ steps.check.outputs.stale }}
+        run: |
+          gh label create doc-review \
+            --description "Scheduled memory-doc reviews that are overdue" \
+            --color BFD4F2 --force
+          body=$(printf 'These memory docs are past their scheduled review (see docs/README.md for the system):\n\n```\n%s\n```\n\nTo clear one: open a Claude session on this repo and run the doc-review skill for the doc, or review it by hand and bump its `last-reviewed` frontmatter.\n\nThis issue is refreshed weekly by the Doc Freshness workflow and can be closed once the listed docs are reviewed.' "$STALE")
+          num=$(gh issue list --state open --label doc-review --json number --jq '.[0].number // empty')
+          if [ -n "$num" ]; then
+            gh issue edit "$num" --body "$body"
+          else
+            gh issue create --title "Overdue memory-doc reviews" --label doc-review --body "$body"
+          fi

--- a/.github/workflows/doc-sync-check.yml
+++ b/.github/workflows/doc-sync-check.yml
@@ -1,0 +1,29 @@
+# PR gate for the shared-memory system (docs/README.md): code in a mapped
+# area (docs/doc-map.tsv) must not change without its docs. Apply the
+# docs-not-needed label when a change genuinely has no doc impact.
+name: Doc Sync
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+permissions:
+  contents: read
+jobs:
+  check:
+    if: "!contains(github.event.pull_request.labels.*.name, 'docs-not-needed')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check mapped code changes carry doc updates
+        env:
+          BASE: ${{ github.base_ref }}
+        run: |
+          if out=$(scripts/check-doc-sync.sh "origin/$BASE"); then
+            echo "Doc sync OK."
+          else
+            echo "$out"
+            echo
+            echo "Docs are this repo's shared memory (docs/README.md). Update the listed doc(s) in this PR (the doc-sync skill gives a guided path), or apply the docs-not-needed label if this change genuinely has no doc impact."
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# GPO Monolith: Claude Guide
+
+## What this repo is, and where it's going
+
+The `gpo-monolith` is the Green Party of Ontario's backend code repo. The legacy
+NestJS + MySQL application that used to live in `src/` was **removed in #89**;
+what remains today is the tax-receipt tooling that survives it (the receipt-PDF
+generation script in `scripts/`, the EO-report Apps Script in
+`google-workspace/`, and the Cypress e2e tests in `gpoAutoTests/`) plus the
+project knowledge base in `docs/`.
+
+New work is a **go-forward stack** tool, starting with the **Tax Receipts &
+Contributions tool** under `apps/tax-receipts/` (not yet scaffolded).
+
+## Go-forward stack (all new work)
+
+- **Backend:** Fastify + Zod (schema-first routes) + Prisma + PostgreSQL.
+- **Frontend:** Vite + React + Mantine + Tanstack Router/Query.
+- **Tooling:** Turborepo + pnpm, SWC, ESLint, Vitest.
+- **Auth:** Passport + bcrypt, stateful sessions; authorization at the query layer
+  (CASL + Prisma).
+
+Rationale is recorded in `docs/tax-receipts-tool/decisions.md` (D1).
+
+## Commands
+
+There is no root build: the legacy NestJS app and its `package.json` are gone.
+The go-forward tool will define its own pnpm/turbo scripts once scaffolded under
+`apps/`. Today's runnable pieces:
+
+```bash
+node scripts/generate_tax_receipt_pdfs/generate.mjs   # stamp receipt PDFs from template
+cd gpoAutoTests && npx cypress run                    # e2e autotests (see its README)
+scripts/check-doc-sync.sh [<base>]                    # did mapped code change without its docs?
+scripts/check-doc-freshness.sh                        # list overdue memory-doc reviews
+```
+
+## Docs are shared memory
+
+Version-controlled docs are how humans and agents share context across
+ephemeral sessions. **`docs/README.md` describes the system; read it before
+changing how docs work.** The working rules:
+
+- **Before working in an area, read its docs.** `docs/doc-map.tsv` maps code
+  areas to their docs; load only what the task needs.
+- **After changing behaviour in a mapped area, update its docs in the same
+  PR.** The Doc Sync check fails any PR that changes a mapped area without
+  touching its docs; the **doc-sync** skill gives the guided path, and the
+  `docs-not-needed` label overrides the check when a change genuinely has no
+  doc impact.
+- **Docs are reviewed on a schedule.** Frontmatter (`last-reviewed`,
+  `review-interval-days`) drives a weekly workflow issue and
+  `scripts/check-doc-freshness.sh`. To clear an overdue doc, run the
+  **doc-review** skill.
+
+## Project knowledge base
+
+**Working on the Tax Receipts & Contributions tool? Read `docs/tax-receipts-tool/`
+first.** Load only what the task needs:
+
+- [`docs/tax-receipts-tool/DESIGN.md`](docs/tax-receipts-tool/DESIGN.md): design and
+  phased roadmap (start here).
+- [`docs/tax-receipts-tool/glossary.md`](docs/tax-receipts-tool/glossary.md):
+  domain terms (CA, TRR, AR-1, S2P2, CFO, target entity, agency fee, and more).
+  Read this if any term is unfamiliar.
+- [`docs/tax-receipts-tool/compliance.md`](docs/tax-receipts-tool/compliance.md):
+  Elections Ontario rules (limits, deadlines, receipt numbering, retention).
+- [`docs/tax-receipts-tool/integrations.md`](docs/tax-receipts-tool/integrations.md):
+  Qomon API + BigQuery warehouse facts and constraints.
+- [`docs/tax-receipts-tool/decisions.md`](docs/tax-receipts-tool/decisions.md):
+  architecture decision log (don't relitigate these).
+- [`docs/tax-receipts-tool/open-questions.md`](docs/tax-receipts-tool/open-questions.md):
+  living list of risks and unknowns to close.
+- [`docs/qomon/`](docs/qomon/README.md): raw Qomon OpenAPI specs (shared in
+  confidence; do not redistribute).
+
+## Conventions & hard rules
+
+- **No CiviCRM integration.** CiviCRM is being decommissioned; the receipts tool
+  reads from **Qomon + the BigQuery warehouse only**. (See `decisions.md` D2.)
+- **Never hard-delete receipt data.** Corrections are cancel/void + an append-only
+  change-log entry. This is a regulatory requirement (`compliance.md`).
+- **Reporting reads hit the warehouse (BigQuery), not Qomon directly.**
+- Keep this CLAUDE.md lean; put durable detail in `docs/`.
+- Writing style for docs: Canadian spelling, Oxford comma, no em-dashes, no
+  horizontal rule directly above a header, text-based formats only.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,149 @@
+---
+last-reviewed: 2026-07-03
+review-interval-days: 180
+---
+
+# Docs are shared memory
+
+This directory is the durable, shared memory of the repo: what the code cannot
+say about itself, kept next to the code and changed through the same PR review
+as the code. It exists because every collaborator, human or Claude agent,
+starts from the same place: sessions are ephemeral, containers are thrown
+away, and only what is committed persists. Knowledge that lives in one
+person's head, one chat transcript, or one Slack thread is lost to everyone
+else; knowledge that lives here is loaded on demand by whoever needs it.
+
+Docs only work as memory if they are trustworthy, so this system forces two
+things: **capture** (docs get updated when the code they cover changes) and
+**review** (every doc gets re-verified against reality on a schedule). Neither
+relies on anyone remembering to do it.
+
+## The loop
+
+1. **Load.** `CLAUDE.md` indexes the memory; an agent or a person reads only
+   the docs the task needs. `docs/doc-map.tsv` says which docs cover which
+   code areas.
+2. **Work.** Normal development.
+3. **Sync.** Changing code in a mapped area obliges a doc check. The **Doc
+   Sync** PR check fails any pull request that changes a mapped area without
+   touching its docs (the `docs-not-needed` label overrides it when a change
+   genuinely has no doc impact), and the **doc-sync** skill gives the guided
+   path: what is worth capturing, which doc it goes in, and in what style.
+4. **Review.** Every memory doc carries `last-reviewed` and
+   `review-interval-days` frontmatter. When a review is overdue, a weekly
+   GitHub Action issue and `scripts/check-doc-freshness.sh` say so, and the
+   **doc-review** skill walks the reviewer through re-verifying the doc claim
+   by claim and bumping the date.
+
+Capture is PR-scoped and event-driven; review is calendar-driven. Together
+they bound how stale any doc can silently get. Capture is enforced at the PR,
+not inside any one editor, deliberately: the merge gate is the one point every
+change passes through, whether it came from a human, a Claude session, or any
+other tool, and it is immune to edits that sidestep an editor's hooks (shell
+commands, scripts, generators).
+
+## Components
+
+| Piece | Role |
+|---|---|
+| `CLAUDE.md` | Index and hard rules, loaded into every agent session. Kept lean; durable detail lives here in `docs/`. |
+| `docs/doc-map.tsv` | Single source of truth mapping code areas to their docs. The check, the skills, and humans all read this one file. |
+| `docs/<area>/*.md` | The memory itself, one directory per project area. |
+| YAML frontmatter (`last-reviewed`, `review-interval-days`) | A doc's freshness contract. Opting a doc in is adding these two lines. |
+| `scripts/check-doc-sync.sh` | The capture check: lists mapped areas changed on a branch without their docs; exit 1 when any. Runnable locally before pushing. |
+| `.github/workflows/doc-sync-check.yml` | Runs the capture check on every PR (the **Doc Sync** check); the `docs-not-needed` label skips it. |
+| `scripts/check-doc-freshness.sh` | Lists overdue docs; exit 1 when anything is overdue. Runnable by anyone, anywhere. |
+| `.github/workflows/doc-freshness.yml` | Weekly check that opens or updates a `doc-review` issue listing overdue docs, so staleness stays visible without nagging every session. |
+| `.claude/skills/doc-sync/` | Guided procedure for folding a code change into the docs. |
+| `.claude/skills/doc-review/` | Guided procedure for a scheduled full review of one doc. |
+| `AGENTS.md` (symlink to `CLAUDE.md`) | The same index for tools that read the vendor-neutral convention (Cursor, Copilot, Codex, and others). |
+
+## The map
+
+`docs/doc-map.tsv` has one rule per line, tab-separated:
+
+```
+<code globs, space-separated>	<doc path or glob>	<what to update>
+```
+
+A rule arms when a changed file matches any code glob, and is satisfied when
+a changed file matches the doc path or glob. The third column is the hint
+shown when the check fails. To change what is watched, edit the map; the
+check and skills pick it up without modification.
+
+## Freshness metadata
+
+Every memory doc starts with:
+
+```yaml
+---
+last-reviewed: 2026-07-03
+review-interval-days: 90
+---
+```
+
+Semantics, and the two rules that keep the date honest:
+
+- `last-reviewed` is bumped **only** by a full review (the doc-review skill),
+  in which every claim was confirmed, fixed, or flagged. A targeted doc-sync
+  edit does not bump it: fixing one sentence says nothing about the other
+  fifty.
+- A review that changes nothing **still** bumps the date. The date records
+  that verification happened, not that content changed.
+
+Choosing an interval: fast-moving docs (open questions, unconfirmed vendor
+facts) get 30 to 60 days; design docs get around 90; stable reference
+(glossary, regulatory rules, decision logs) gets 180. Reviews may adjust the
+interval, with a stated reason, as a doc's churn becomes clear.
+
+## Living memory vs reference snapshots
+
+Living docs (design, integrations, open questions) assert facts about the
+present and must track it. Snapshots (for example the vendor API specs under
+`docs/qomon/`) are point-in-time artifacts: a review does not edit them, it
+asks whether the snapshot is old enough to re-request from the source. Both
+kinds carry freshness frontmatter; only the review action differs.
+
+## Adding a new memory area
+
+1. Create `docs/<area>/` with the doc(s). Prefer a few single-purpose docs
+   over one long one, so sessions can load only what a task needs.
+2. Add frontmatter to each doc with today's date and a chosen interval.
+3. Add a rule to `docs/doc-map.tsv` mapping the code area to the docs.
+4. Add the area to the knowledge-base section of `CLAUDE.md`, one line per
+   doc saying when to load it.
+
+The checks, skills, and workflows need no changes.
+
+## What belongs in memory docs
+
+Capture what the code cannot say and a future session would otherwise
+rediscover the hard way: decisions and their why, domain rules, external and
+vendor facts, constraints and invariants, known risks, and open questions.
+Do not capture what the code already says (narrated implementations go stale
+the moment the code moves), transient status better suited to an issue or PR,
+or secrets and credentials of any kind.
+
+## Writing conventions
+
+Concise and factual. Canadian spelling, Oxford comma, no em-dashes, no
+horizontal rule directly above a header. Text-based formats only: Markdown,
+Mermaid, CSV/TSV. Write for a reader with zero session context, and link to
+sources (Drive doc ids, spec files, handbook sections) so claims can be
+re-verified later.
+
+## Porting this to another repo
+
+The system is self-contained and copies cleanly. This repo holds the
+canonical version; port from here rather than forking a variant (gpo-data is
+the intended next home, and its existing inline-rules doc hook should be
+replaced by this, not kept alongside it):
+
+1. Copy `.claude/skills/`, `scripts/check-doc-sync.sh`, and
+   `scripts/check-doc-freshness.sh` as-is.
+2. Copy `.github/workflows/doc-sync-check.yml` and
+   `.github/workflows/doc-freshness.yml` as-is.
+3. Write that repo's `docs/doc-map.tsv` and add frontmatter to its docs.
+4. Add the shared-memory section to that repo's `CLAUDE.md`.
+
+Only step 3 and step 4 contain repo-specific content.

--- a/docs/doc-map.tsv
+++ b/docs/doc-map.tsv
@@ -1,0 +1,10 @@
+# Shared memory map: which docs cover which areas of the repo.
+# One rule per line, tab-separated:
+#   <code globs, space-separated>	<doc path or glob>	<what to update>
+# A rule arms when any edited file matches a code glob; it is satisfied when
+# any edited file matches the doc path or glob.
+# Consumed by .claude/hooks/doc-sync-reminder.sh and the doc-sync skill, and
+# referenced from CLAUDE.md. Edit this file, not the hook, to change coverage.
+apps/tax-receipts/*	docs/tax-receipts-tool/*	DESIGN.md / integrations.md / compliance.md / decisions.md / open-questions.md
+scripts/generate_tax_receipt_pdfs/*	docs/tax-receipts-tool/*	DESIGN.md section 4.1 (current process) / open-questions.md
+google-workspace/*	docs/tax-receipts-tool/*	DESIGN.md section 4.1 (current process)

--- a/docs/qomon/README.md
+++ b/docs/qomon/README.md
@@ -1,3 +1,8 @@
+---
+last-reviewed: 2026-07-03
+review-interval-days: 180
+---
+
 # Qomon API — OpenAPI / Swagger specs
 
 OpenAPI 3.0/3.1 specifications for [Qomon](https://qomon.com)'s API, which the

--- a/scripts/check-doc-freshness.sh
+++ b/scripts/check-doc-freshness.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# List memory docs whose scheduled review is overdue.
+#
+# A doc opts in to freshness tracking with YAML frontmatter:
+#   ---
+#   last-reviewed: YYYY-MM-DD
+#   review-interval-days: N
+#   ---
+# Reviews are performed with the doc-review skill (.claude/skills/doc-review),
+# which bumps last-reviewed. See docs/README.md for the full system.
+#
+# Output: one overdue doc per line (tab-separated: path, last reviewed, days
+# overdue). Exit 0 when everything is fresh, 1 when anything is overdue or a
+# doc's frontmatter is malformed.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+today=$(date -u +%s)
+stale=0
+
+# frontmatter <file> <key>: value of <key> inside the leading --- block, if any.
+frontmatter() {
+  awk -F': *' -v key="$2" '
+    NR==1 && $0 != "---" { exit }
+    /^---[[:space:]]*$/ { fences++; if (fences == 2) exit; next }
+    fences == 1 && $1 == key { print $2; exit }
+  ' "$1"
+}
+
+while IFS= read -r doc; do
+  reviewed=$(frontmatter "$doc" "last-reviewed")
+  interval=$(frontmatter "$doc" "review-interval-days")
+  [ -n "$reviewed" ] || continue
+  reviewed_epoch=$(date -u -d "$reviewed" +%s 2>/dev/null) || {
+    printf '%s\tmalformed last-reviewed: %s\n' "$doc" "$reviewed"
+    stale=1
+    continue
+  }
+  case "$interval" in
+    ''|*[!0-9]*)
+      printf '%s\tmalformed review-interval-days: %s\n' "$doc" "${interval:-missing}"
+      stale=1
+      continue
+      ;;
+  esac
+  due=$((reviewed_epoch + interval * 86400))
+  if [ "$due" -lt "$today" ]; then
+    printf '%s\tlast reviewed %s\t%d days overdue\n' \
+      "$doc" "$reviewed" "$(((today - due) / 86400))"
+    stale=1
+  fi
+done < <(grep -rl --include='*.md' '^last-reviewed:' CLAUDE.md docs 2>/dev/null)
+
+exit "$stale"

--- a/scripts/check-doc-sync.sh
+++ b/scripts/check-doc-sync.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Check that docs were updated alongside the code areas they cover.
+#
+# Rules live in docs/doc-map.tsv: a rule arms when a changed file matches any
+# of its code globs, and is satisfied when a changed file matches the doc path
+# or glob. Prints one line per unsatisfied rule; exit 1 when any rule is
+# unsatisfied. See docs/README.md for the system this belongs to.
+#
+# Usage: scripts/check-doc-sync.sh [<base>]
+# Compares <base>...HEAD (merge-base diff); <base> defaults to origin/main.
+# Run by the Doc Sync workflow on every PR; runnable locally before pushing.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+base="${1:-origin/main}"
+map=docs/doc-map.tsv
+[ -f "$map" ] || exit 0
+
+CHANGED=()
+while IFS= read -r f; do [ -n "$f" ] && CHANGED+=("$f"); done \
+  < <(git diff --name-only "$base"...HEAD)
+[ "${#CHANGED[@]}" -eq 0 ] && exit 0
+
+# matches <glob>: true if any changed file matches the glob (case-pattern).
+matches() {
+  local p="$1" f
+  for f in "${CHANGED[@]}"; do
+    case "$f" in $p) return 0 ;; esac
+  done
+  return 1
+}
+
+status=0
+while IFS=$'\t' read -r globs doc hint; do
+  case "$globs" in ''|'#'*) continue ;; esac
+  for g in $globs; do
+    if matches "$g" && ! matches "$doc"; then
+      printf '%s changed but %s did not: update %s.\n' "$globs" "$doc" "$hint"
+      status=1
+      break
+    fi
+  done
+done < "$map"
+
+exit "$status"


### PR DESCRIPTION
The memory-system half of #91, split out and reworked so the design docs and the memory infrastructure get reviewed separately. `docs/README.md` in this PR describes the whole system; this body covers what changed relative to #91's version.

## Kept from #91

- Lean root `CLAUDE.md` as index + hard rules, with progressive disclosure into `docs/`.
- `docs/README.md` (system doc) and `docs/doc-map.tsv` as the single source of truth mapping code areas to docs.
- The `doc-sync` and `doc-review` skills.
- Calendar-driven freshness: `last-reviewed` / `review-interval-days` frontmatter, `scripts/check-doc-freshness.sh`, and the weekly issue workflow. Kept because most memory docs assert external facts (Qomon behaviour, Elections Ontario rules) whose staleness is never triggered by a repo diff.

## Changed: capture enforcement moves from agent hooks to a PR check

The Stop/PostToolUse hook pipeline is replaced by a **Doc Sync** PR check (`scripts/check-doc-sync.sh` + `.github/workflows/doc-sync-check.yml`) driven by the same `doc-map.tsv`. Reasons:

- The hooks only saw `Write`/`Edit` tool calls: edits via Bash (sed, codemods, generators), human editors, and non-Claude agents all bypassed them.
- The touch-list tmp file was keyed by project path only, so two concurrent sessions in one checkout shared and clobbered each other's state.
- Block-once-then-allow is trivially bypassed and added a turn of latency to every session working in a mapped area.

The PR check enforces the same rule at the one gate every change passes through, for every editor. The `docs-not-needed` label is the override for changes with genuinely no doc impact. The check is runnable locally: `scripts/check-doc-sync.sh [<base>]`.

## Dropped

- The SessionStart freshness notice: it injected overdue-doc noise into every session regardless of task; the weekly issue already surfaces staleness.
- `.claude/settings.json`: no hooks remain to configure.
- From `CLAUDE.md`: frontmatter, the layout tree (paths drift; the knowledge-base section covers discovery), and the branch/PR workflow bullet (harness-enforced already).

## Added

- `AGENTS.md` symlink to `CLAUDE.md`, so tools reading the vendor-neutral convention (Cursor, Copilot, Codex) load the same index.

## Notes for review

- `doc-map.tsv` and `CLAUDE.md` reference `docs/tax-receipts-tool/`, which lands in #91; merge order between the two PRs does not matter, but links resolve only once both are in.
- The `docs-not-needed` label and the `doc-review` label are created on first use by the workflows or can be created manually.
- Tested: the sync checker exits 1 with a hint when a mapped area changes without its doc, and 0 once the doc rides along; the freshness checker exits 0 on the current tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168ZBoqqwKr5f94eSxuujw7

---
_Generated by [Claude Code](https://claude.ai/code/session_0168ZBoqqwKr5f94eSxuujw7)_