### PR TITLE
Add CLAUDE.md and cloud-session hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -uo pipefail
+
+# Only run this in Claude Code on the web / remote sandboxes. The container
+# state is cached after this hook completes, so installs are one-time per
+# environment build, not per session.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR/gpoAutoTests"
+
+# The Cypress binary download (download.cypress.io) is blocked in the
+# sandbox, and the e2e suite targets staging.gpo.ca anyway. Install node
+# deps for eslint/tsc only.
+echo "==> npm install (gpoAutoTests, skipping Cypress binary)"
+CYPRESS_INSTALL_BINARY=0 npm install || echo "!! npm install failed"
+
+echo "==> session-start hook complete"
+echo "    Validate spec changes with: cd gpoAutoTests && ./node_modules/.bin/eslint . && npx tsc --noEmit"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/setup-env.sh
+++ b/.claude/setup-env.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Claude Code cloud environments: reference this from the environment's
+# Setup script field (see README) to pre-bake this repo's dependencies into
+# the cached environment image. Sessions then start warm; the SessionStart
+# hook re-runs the same steps per session as a fast, idempotent reconciler
+# (and restarts services, which the image cache never preserves).
+#
+# Fail-soft: a broken install must not block environment creation.
+set -u
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+CLAUDE_CODE_REMOTE=true CLAUDE_PROJECT_DIR="$REPO_DIR" \
+  bash "$REPO_DIR/.claude/hooks/session-start.sh" || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# GPO Monolith
+
+Grab-bag repo for GPO operational assets that do not have a home of their own: Cypress e2e tests against the live sites, Qomon API specs, tax-receipt tooling, and one-off scripts. There is no single build or runtime.
+
+## Repo map
+
+```
+gpoAutoTests/        Cypress e2e suite, runs against https://staging.gpo.ca
+                     (weekly smoke run + full run via GitHub Actions)
+docs/qomon/          OpenAPI 3.x specs for the Qomon API (CRM platform)
+google-workspace/    tax_receipts_split_main_into_eo_reports.js (Apps Script)
+scripts/generate_tax_receipt_pdfs/  Tax-receipt PDF generation (generate.mjs + template.pdf)
+scripts/send_email.mjs              Email sending helper
+```
+
+## gpoAutoTests (Cypress)
+
+- Config: `gpoAutoTests/cypress.config.ts` — `baseUrl` is **staging.gpo.ca**; these tests exercise a deployed site, not local code.
+- Run locally: `cd gpoAutoTests && npx cypress run` (or `--env grepTags=@smoke`).
+- Lint: `cd gpoAutoTests && ./node_modules/.bin/eslint --fix .` (in sandboxes, `npx eslint` mis-resolves to an incompatible global ESLint; always use the local binary)
+- CI: `.github/workflows/e2e_smoke_tests.yml` (weekly + manual) and `e2e_all_tests.yml`. Trigger these to validate test changes rather than hitting staging from a sandbox.
+- In cloud sandboxes the Cypress binary is not downloadable and staging may be unreachable — treat e2e runs as CI/local-only; validate spec changes with eslint + tsc.
+
+## Conventions
+
+- The Qomon OpenAPI specs in `docs/qomon/` are reference documentation for integrations elsewhere (gpo-ca, gpo-data); update them from Qomon's published specs, do not hand-tune them to match observed behaviour.
+- Tax-receipt tooling here pairs with the annual workflow in `gpo-data/reports/tax-receipts/` — check that repo before changing formats.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 ![Monolith](docs/readme-images/monolith.png)
 # The Green Party of Ontario Monolith
+
+## Claude Code cloud environments
+
+Sessions in [Claude Code on the web](https://claude.ai/code) install this repo's dependencies at session start via `.claude/hooks/session-start.sh`. To pre-bake them into the cached environment image instead (sessions start warm, and install failures surface at environment build rather than mid-task), add this line to the environment's **Setup script** field, alongside the equivalent line from any other attached repo you want pre-built:
+
+```bash
+bash /home/user/gpo-monolith/.claude/setup-env.sh || true
+```
+
+The path matches where Claude Code cloud environments clone this repo.


### PR DESCRIPTION
Part of the agentic-setup review across GPO repos.

- **CLAUDE.md** — maps the repo (Cypress e2e suite vs staging.gpo.ca, Qomon OpenAPI specs, tax-receipt tooling) and documents verification: local eslint binary + `tsc --noEmit` for spec changes, CI workflows for actual e2e runs.
- **`.claude/hooks/session-start.sh`** — installs gpoAutoTests node deps in cloud sessions with `CYPRESS_INSTALL_BINARY=0` (the binary download is blocked in the sandbox, and the suite targets staging anyway).
- **`.claude/setup-env.sh`** + README section — optional: paste the documented one-liner into a cloud environment's **Setup script** field to pre-bake the install into the cached environment image.

Validated in a sandbox: hook and `setup-env.sh` green, `tsc --noEmit` clean, local eslint runs (it reports two pre-existing `ban-ts-comment` errors in `cypress/support/e2e.ts` — left untouched as out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wucnc7eo6GpirHruYUa7ep