### PR TITLE
docs: adopt first-mention linking convention

### DIFF
--- a/.claude/skills/doc-review/SKILL.md
+++ b/.claude/skills/doc-review/SKILL.md
@@ -28,7 +28,9 @@ bumps `last-reviewed` so the freshness system knows it was done. See
      it to `open-questions.md` with what would confirm it.
 4. **Look for the missing.** Scan the mapped code areas (and recent commits
    touching them, `git log --oneline -- <area>`) for things that exist but the
-   doc does not mention. Add what a future reader would need.
+   doc does not mention. Add what a future reader would need. Unlinked
+   mentions count as missing: where a term, decision, or subject has a
+   covering doc, add the first-mention link.
 5. **Reassess the cadence.** If the doc churned a lot, shorten
    `review-interval-days`; if it was all confirmed, consider lengthening.
    Adjust only with a reason, and say so in your reply.
@@ -42,4 +44,6 @@ bumps `last-reviewed` so the freshness system knows it was done. See
 
 Concise and factual, Canadian spelling, Oxford comma, no em-dashes, no
 horizontal rule directly above a header, text-based formats only (Markdown,
-Mermaid, CSV/TSV). Write for a reader with zero session context.
+Mermaid, CSV/TSV). Write for a reader with zero session context. Link on
+first mention: the first time you name a domain term, a decision, or another
+doc's subject, link its doc (repo-relative paths); once per doc is enough.

--- a/.claude/skills/doc-sync/SKILL.md
+++ b/.claude/skills/doc-sync/SKILL.md
@@ -48,4 +48,6 @@ what a future session would otherwise have to rediscover.
 
 Concise and factual, Canadian spelling, Oxford comma, no em-dashes, no
 horizontal rule directly above a header, text-based formats only (Markdown,
-Mermaid, CSV/TSV). Write for a reader with zero session context.
+Mermaid, CSV/TSV). Write for a reader with zero session context. Link on
+first mention: the first time you name a domain term, a decision, or another
+doc's subject, link its doc (repo-relative paths); once per doc is enough.

--- a/docs/README.md
+++ b/docs/README.md
@@ -132,6 +132,13 @@ Mermaid, CSV/TSV. Write for a reader with zero session context, and link to
 sources (Drive doc ids, spec files, handbook sections) so claims can be
 re-verified later.
 
+Link on first mention. The first time a doc names a domain term, link the
+glossary entry; the first time it leans on a decision, link the decision log
+entry; the first time it touches another doc's subject, link that doc. Use
+repo-relative paths. One link at first mention is enough; do not re-link
+every occurrence. Links are how a reader, human or agent, traverses the
+memory without searching it.
+
 ## Porting this to another repo
 
 The system is self-contained and copies cleanly. This repo holds the


### PR DESCRIPTION
Adds a linking convention to the shared-memory system (follow-up to #92): the first time a doc names a domain term, leans on a decision, or touches another doc's subject, it links the covering doc (glossary entry, decision log entry, or the doc itself) with a repo-relative path. One link at first mention; no re-linking every occurrence.

Rationale: links are how a reader traverses the memory without searching it. For an agent, an unlinked mention of a term like S2P2 or D2 costs a grep round-trip, or worse, proceeds on a guess. First-mention bounds the convention so docs don't become link noise, and link rot is already covered by the doc-review cadence (links are claims, and claims get verified), so no new checker is added.

Changes:
- `docs/README.md`: linking rule added to Writing conventions.
- `.claude/skills/doc-sync/SKILL.md`: same rule in the skill's conventions, so new writing follows it.
- `.claude/skills/doc-review/SKILL.md`: same rule, plus step 4 now treats unlinked mentions as missing content, so existing docs pick up links as they come up for review.

Second commit: the system's canonical source is now the doc-memory skill bundle (install-doc-memory / update-doc-memory, kept in dotfiles), and this repo is an install of it. `docs/README.md` gains a `doc-memory-version: 3` frontmatter stamp that the update skill compares against the bundle changelog, and the porting section now points at the bundle instead of claiming this repo as the canonical copy. The freshness checker ignores the extra frontmatter key (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168ZBoqqwKr5f94eSxuujw7