### PR TITLE
docs: date external facts and repair in-doc contradictions on review

### DIFF
--- a/.claude/skills/doc-review/SKILL.md
+++ b/.claude/skills/doc-review/SKILL.md
@@ -21,11 +21,21 @@ bumps `last-reviewed` so the freshness system knows it was done. See
    guidance, Drive documents, Slack).
 3. **Verify claim by claim.** For each factual claim, path, command, and
    cross-reference in the doc:
-   - **confirmed** → leave it;
+   - **confirmed** → leave it; a dated external fact re-verified against its
+     source gets its as-of date refreshed;
    - **stale** → fix it (repo-verifiable claims: check the code, run the
      command; do not guess);
    - **unverifiable from the repo** → leave it, but if it looks doubtful, add
      it to `open-questions.md` with what would confirm it.
+   Claims are not independent: also compare them to each other. Two claims
+   about the same fact (often an appended update sitting beside the sentence
+   it should have replaced) are the failure this system exists to prevent,
+   and this comparison holds even when both claims are individually
+   unverifiable. Collapse them into one current claim, stated once, where a
+   reader would look for it; the as-of dates say which is newer. If you
+   cannot tell whether the difference is a correction or a genuine change
+   over time, keep the newer claim and move the question to
+   `open-questions.md`.
 4. **Look for the missing.** Scan the mapped code areas (and recent commits
    touching them, `git log --oneline -- <area>`) for things that exist but the
    doc does not mention. Add what a future reader would need. Unlinked
@@ -46,4 +56,7 @@ Concise and factual, Canadian spelling, Oxford comma, no em-dashes, no
 horizontal rule directly above a header, text-based formats only (Markdown,
 Mermaid, CSV/TSV). Write for a reader with zero session context. Link on
 first mention: the first time you name a domain term, a decision, or another
-doc's subject, link its doc (repo-relative paths); once per doc is enough.
+doc's subject, link its doc (repo-relative paths); once per doc is enough. Date
+external facts: a claim about an external system, vendor, or rule carries an
+as-of date ("as of 2026-06") and its source; re-verifying against the source
+refreshes the date.

--- a/.claude/skills/doc-sync/SKILL.md
+++ b/.claude/skills/doc-sync/SKILL.md
@@ -18,7 +18,8 @@ what a future session would otherwise have to rediscover.
    decide that is not obvious from the code itself? Capture durable facts only:
    - behaviour or interface changes, and new constraints or invariants;
    - decisions made (and rejected alternatives, briefly);
-   - external facts learned (API quirks, regulatory rules, vendor commitments);
+   - external facts learned (API quirks, regulatory rules, vendor
+     commitments), each dated ("as of 2026-06") with its source;
    - open questions resolved, or new risks discovered.
    A pure refactor with no behaviour change usually needs no doc edit; in that
    case stop here and say so.
@@ -50,4 +51,7 @@ Concise and factual, Canadian spelling, Oxford comma, no em-dashes, no
 horizontal rule directly above a header, text-based formats only (Markdown,
 Mermaid, CSV/TSV). Write for a reader with zero session context. Link on
 first mention: the first time you name a domain term, a decision, or another
-doc's subject, link its doc (repo-relative paths); once per doc is enough.
+doc's subject, link its doc (repo-relative paths); once per doc is enough. Date
+external facts: a claim about an external system, vendor, or rule carries an
+as-of date ("as of 2026-06") and its source; re-verifying against the source
+refreshes the date.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 ---
 last-reviewed: 2026-07-03
 review-interval-days: 180
-doc-memory-version: 3
+doc-memory-version: 4
 ---
 
 # Docs are shared memory
@@ -139,6 +139,13 @@ entry; the first time it touches another doc's subject, link that doc. Use
 repo-relative paths. One link at first mention is enough; do not re-link
 every occurrence. Links are how a reader, human or agent, traverses the
 memory without searching it.
+
+Date external facts. A claim about an external system, vendor, or rule
+carries the date it was last observed true ("as of 2026-06") and its source.
+`last-reviewed` records when a whole doc was verified; an as-of date records
+when a single fact was. Re-verifying a claim against its source refreshes its
+date, and when two versions of the same fact meet, the as-of dates say which
+one is current.
 
 ## Porting this to another repo
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,7 @@
 ---
 last-reviewed: 2026-07-03
 review-interval-days: 180
+doc-memory-version: 3
 ---
 
 # Docs are shared memory
@@ -141,16 +142,11 @@ memory without searching it.
 
 ## Porting this to another repo
 
-The system is self-contained and copies cleanly. This repo holds the
-canonical version; port from here rather than forking a variant (gpo-data is
-the intended next home, and its existing inline-rules doc hook should be
-replaced by this, not kept alongside it):
-
-1. Copy `.claude/skills/`, `scripts/check-doc-sync.sh`, and
-   `scripts/check-doc-freshness.sh` as-is.
-2. Copy `.github/workflows/doc-sync-check.yml` and
-   `.github/workflows/doc-freshness.yml` as-is.
-3. Write that repo's `docs/doc-map.tsv` and add frontmatter to its docs.
-4. Add the shared-memory section to that repo's `CLAUDE.md`.
-
-Only step 3 and step 4 contain repo-specific content.
+The canonical source is the **doc-memory** skill bundle (the
+install-doc-memory and update-doc-memory skills); this repo is an install of
+it, stamped with `doc-memory-version` in this file's frontmatter. To add the
+system to another repo, run install-doc-memory there rather than copying this
+repo's files (gpo-data is the intended next home, and its existing
+inline-rules doc hook should be replaced by this, not kept alongside it).
+When the bundle evolves past this repo's stamp, update-doc-memory brings the
+install up to date.


### PR DESCRIPTION
Two commits. The second is the substance; the first re-lands work that missed the #94 merge.

## Commit 2: as-of dating + contradiction repair (doc-memory v4)

**Date external facts.** A claim about an external system, vendor, or rule now carries the date it was last observed true ("as of 2026-06") and its source. `last-reviewed` records when a whole doc was verified; an as-of date records when a single fact was. Added to the Writing conventions in `docs/README.md` and both skills; the doc-sync skill dates external facts at capture, and doc-review refreshes a fact's date when it re-verifies against the source. Existing facts pick up dates as they come up for review; no bulk pass.

**Make doc-review resilient to the append failure.** The system's suppression guarantee (only one current version of a fact exists) depends on doc-sync's edit-in-place rule. If someone appends "Update, July: actually..." beside the sentence it should have replaced, the old doc-review procedure could verify both claims independently, and when both were externally sourced and unverifiable from the repo, both survived. Step 3 now states that claims are not independent: two claims about the same fact get collapsed into one current claim even when both are individually unverifiable, with as-of dates deciding which is newer, and correction-vs-genuine-change ambiguity routed to `open-questions.md` instead of guessed.

## Commit 1: re-land the v3 version stamp

`docs/README.md` gains the `doc-memory-version` frontmatter stamp and the porting section now points at the doc-memory skill bundle as the canonical source. This was pushed to the #94 branch after that PR was merged, so it never reached main; cherry-picked here, with the stamp landing at 4 to match this PR's content. The freshness checker ignores the extra frontmatter key (verified earlier on the same change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168ZBoqqwKr5f94eSxuujw7

---
_Generated by [Claude Code](https://claude.ai/code/session_0168ZBoqqwKr5f94eSxuujw7)_